### PR TITLE
#33 cqrs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,39 +1,96 @@
 services:
-  db-mysql:
+  # Kafka
+  kafka:
+    image: bitnami/kafka:latest
+    networks:
+      - kafka_network
+    ports:
+      - '9094:9094'
+    environment:
+      KAFKA_CFG_NODE_ID: 0
+      KAFKA_CFG_PROCESS_ROLES: controller,broker
+      KAFKA_CFG_CONTROLLER_QUORUM_VOTERS: 0@kafka:9093
+      KAFKA_CFG_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093,EXTERNAL://:9094
+      KAFKA_CFG_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,EXTERNAL://localhost:9094
+      KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,EXTERNAL:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      KAFKA_CFG_CONTROLLER_LISTENER_NAMES: CONTROLLER
+
+  # Kafka Connect (Debezium)
+  connect:
+    build:
+      context: ./mnt/connect
+      dockerfile: Dockerfile
+    networks:
+      - kafka_network
+    ports:
+      - "8083:8083"
+    depends_on:
+      - kafka
+    environment:
+      BOOTSTRAP_SERVERS: kafka:9092
+      GROUP_ID: connect-cluster
+      CONFIG_STORAGE_TOPIC: connect-configs
+      OFFSET_STORAGE_TOPIC: connect-offsets
+      STATUS_STORAGE_TOPIC: connect-status
+      CONNECT_KEY_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_VALUE_CONVERTER: org.apache.kafka.connect.json.JsonConverter
+      CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: false
+      CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: false
+      CONNECT_PLUGIN_PATH: "/kafka/connect,/kafka/connect/elasticsearch"
+
+  # Elasticsearch
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
+    networks:
+      - app_network
+      - kafka_network
+    ports:
+      - "9200:9200"
+    environment:
+      discovery.type: single-node
+
+  # MySQL
+  mysql:
     image: mysql:8.3.0
-    restart: always
+    networks:
+      - app_network
+      - kafka_network
     ports:
       - "3306:3306"
     volumes:
       - ./src/main/resources/db/init:/docker-entrypoint-initdb.d
+    healthcheck:
+      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      timeout: 2s
+      retries: 5
+    restart: always
     environment:
       MYSQL_ROOT_PASSWORD: not_allowed_go_away
       MYSQL_USER: test_user
       MYSQL_PASSWORD: test_password
       MYSQL_DATABASE: test_db
-    healthcheck:
-      test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
-      timeout: 5s
-      retries: 2
-    networks:
-      - network
+
+  # Spring Application
   app:
     build:
       context: .
       dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
-    environment:
-      - SPRING_DATASOURCE_URL=jdbc:mysql://db-mysql:3306/test_db
-      - SPRING_DATASOURCE_USERNAME=test_user
-      - SPRING_DATASOURCE_PASSWORD=test_password
-      - SPRING_MAIL_HOST=smtp.some_domain.com
-      - SPRING_MAIL_USERNAME=not_allowed@some_domain.com
-      - SPRING_MAIL_PASSWORD=xxxxxx
-    depends_on:
-      db-mysql:
-        condition: service_healthy
     networks:
-      - network
+      - app_network
+    ports:
+      - "9090:9090"
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db-app:3306/test_db
+      SPRING_DATASOURCE_USERNAME: test_user
+      SPRING_DATASOURCE_PASSWORD: test_password
+      SPRING_MAIL_HOST: smtp.some_domain.com
+      SPRING_MAIL_USERNAME: not_allowed@some_domain.com
+      SPRING_MAIL_PASSWORD: xxxxxx
+
 networks:
-  network:
+  app_network:
+  kafka_network:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,19 @@ services:
       - kafka_network
     ports:
       - "8083:8083"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8083" ]
+      interval: 3s
+      timeout: 2s
+      retries: 5
+      start_period: 10s
     depends_on:
-      - kafka
+      kafka:
+        condition: service_started
+      elasticsearch:
+        condition: service_started
+      mysql:
+        condition: service_healthy
     environment:
       BOOTSTRAP_SERVERS: kafka:9092
       GROUP_ID: connect-cluster
@@ -37,6 +48,25 @@ services:
       CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE: false
       CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE: false
       CONNECT_PLUGIN_PATH: "/kafka/connect,/kafka/connect/elasticsearch"
+
+  # Kafka Connect (Debezium) Initializer
+  connect_initializer:
+    image: curlimages/curl
+    networks:
+      - kafka_network
+    volumes:
+      - ./mnt/connect/mysql-source.json:/config/source.json
+      - ./mnt/connect/es-sink.json:/config/sink.json
+    depends_on:
+      connect:
+        condition: service_healthy
+    entrypoint: [
+      "sh",
+      "-c",
+      "curl -X POST -H 'Content-Type: application/json' --data @/config/source.json http://connect:8083/connectors && \
+       curl -X POST -H 'Content-Type: application/json' --data @/config/sink.json http://connect:8083/connectors"
+    ]
+    restart: no
 
   # Elasticsearch
   elasticsearch:
@@ -61,9 +91,10 @@ services:
       - ./src/main/resources/db/init:/docker-entrypoint-initdb.d
     healthcheck:
       test: [ "CMD", "mysqladmin" ,"ping", "-h", "localhost" ]
+      interval: 3s
       timeout: 2s
       retries: 5
-    restart: always
+      start_period: 5s
     environment:
       MYSQL_ROOT_PASSWORD: not_allowed_go_away
       MYSQL_USER: test_user
@@ -82,8 +113,10 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
+      elasticsearch:
+        condition: service_started
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://db-app:3306/test_db
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/test_db
       SPRING_DATASOURCE_USERNAME: test_user
       SPRING_DATASOURCE_PASSWORD: test_password
       SPRING_MAIL_HOST: smtp.some_domain.com
@@ -93,4 +126,3 @@ services:
 networks:
   app_network:
   kafka_network:
-

--- a/mnt/connect/Dockerfile
+++ b/mnt/connect/Dockerfile
@@ -1,0 +1,8 @@
+FROM quay.io/debezium/connect:latest
+
+COPY confluentinc-kafka-connect-elasticsearch-14.1.2.zip /tmp/elasticsearch-connector.zip
+RUN mkdir -p /kafka/connect/elasticsearch \
+    && unzip /tmp/elasticsearch-connector.zip -d /kafka/connect/elasticsearch
+
+# Kafka Connect 플러그인 경로 설정
+ENV CONNECT_PLUGIN_PATH="/kafka/connect,/kafka/connect/elasticsearch"

--- a/mnt/connect/es-sink.json
+++ b/mnt/connect/es-sink.json
@@ -1,0 +1,13 @@
+{
+  "name": "elasticsearch-sink-connector",
+  "config": {
+    "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
+    "connection.url": "http://elasticsearch:9200",
+    "type.name": "_doc",
+    "topics": "cdc.test_db.posts",
+    "key.ignore": "true",
+    "schema.ignore": "true",
+    "transforms": "unwrap",
+    "transforms.unwrap.type": "io.debezium.transforms.ExtractNewRecordState"
+  }
+}

--- a/mnt/connect/es-sink.json
+++ b/mnt/connect/es-sink.json
@@ -4,7 +4,7 @@
     "connector.class": "io.confluent.connect.elasticsearch.ElasticsearchSinkConnector",
     "connection.url": "http://elasticsearch:9200",
     "type.name": "_doc",
-    "topics": "cdc.test_db.posts",
+    "topics.regex": "cdc.test_db.+",
     "key.ignore": "true",
     "schema.ignore": "true",
     "transforms": "unwrap",

--- a/mnt/connect/mysql-source.json
+++ b/mnt/connect/mysql-source.json
@@ -1,0 +1,22 @@
+{
+  "name": "mysql-source-connector",
+  "config": {
+    "connector.class": "io.debezium.connector.mysql.MySqlConnector",
+    "topic.prefix": "cdc",
+    "database.hostname": "mysql",
+    "database.port": "3306",
+    "database.user": "root",
+    "database.password": "not_allowed_go_away",
+    "database.server.id": "184054",
+    "database.server.name": "test_mysql",
+    "database.include.list": "test_db",
+    "database.history.kafka.bootstrap.servers": "kafka:9092",
+    "database.history.kafka.topic": "schema-changes.test_db",
+    "schema.history.internal.kafka.bootstrap.servers": "kafka:9092",
+    "schema.history.internal.kafka.topic": "schema-history.test_db",
+    "include.schema.changes": "true",
+    "database.serverTimezone": "UTC",
+    "decimal.handling.mode": "double",
+    "time.precision.mode": "connect"
+  }
+}


### PR DESCRIPTION
## 🔗다음 이슈를 해결했어요.

- close #33 


## 📄변경 사항

### `docker-compose` 구성
1. `kafka`
기존에는 kafka 클러스터링을 구축하려면 메타데이터 관리를 해 줄 `zookeeper`가 필수였는데, `kraft`모드를 지원하면서 이제는 Kafka 자체적으로 클러스터링을 할 수 있게 되었습니다. 현재는 단일 브로커로 구성되어 있습니다.

2. `kafka connect`(`debezium`)
`debezium`이 Elasticsearch(이하 `ES`) 모듈을 지원하지 않기 때문에 confluent 사에서 만든 module을 설치하여 사용하고 있습니다. 도커 이미지 빌드시 ES-connect 모듈을 설치하고, 의존하는 다른 서비스가 구동되는 시점에 환경변수를 적용해서 실행하게 되어있습니다.

3. `ES`
특별한 설정은 하지 않았습니다. 현재 단일 노드로 구성되어 있습니다.

cf. network
`kafka` 및 `kafka connect`는 app에서 알 필요가 없으므로 별도의 network(`kafka_network`)에서 실행됩니다. (app은 `app_network`)


![image](https://github.com/user-attachments/assets/f868c28e-7ef9-4aaf-8575-bff6d883338d)


## 💡고민 사항

### kafka connect configure
`kafka connect`의 source/sink connect 설정을 할 때는 서버에 API 호출을 해야 합니다.
`kafka connect` 컨테이너 내부에서 이 작업을 하는 게 쉽지도 않고, 컨테이너는 (다른 서비스의 세부적인 설정에 의존하기 보다는) 독립적으로 실행되는 것이 바람직하다고 생각되어서 `connect_initializer`라는 별도의 컨테이너에서 API를 호출하게 만들었습니다. (이 컨테이너는 API를 호출하고 즉시 종료됩니다.)

### Source-to-Target Latency
MySQL에 insert가 발생한 시점부터 ES에 데이터가 업데이트 되는 데까지 걸리는 시간을 제어보니 30초 소요되었습니다. 생각보다 오래 소요되었고, 트래픽이 조금만 발생해도 크게 늘어나지 않을지 염려되어서 지속적인 모니터링이 필요하다고 생각됩니다.
[Debezium 공식문서](https://toss.tech/article/cdc_pipeline)에서는 `Prometheus` 및 `Grafana`로 통합할 수 있다고 안내하고 있습니다. 따라서 추후 모니터링 구현할 때 추가하도록 하겠습니다. 또한 토스증권에서도 [비슷한 문제](https://toss.tech/article/cdc_pipeline)를 겪은 것 같은데 제공하는 지표가 너무 적어서 몇가지 추가하여 사용한 것 같습니다.

> 하지만 Debezium에서 제공하는 지표은 아래의 4가지입니다. 모두 1) 원천 Log로부터 읽어들인 event의 양에 대한 지표만 제공하죠.
> TotalNumberOfEventSeen
> TotalNumberOfCreateEventSeen
> TotalNumberOfUpdateEventSeen
> TotalNumberOfDeleteEventSeen


## 📑첨부 자료

- [Docker Compose를 통해 Kafka 구축하기 - Kraft 모드](https://kylo8.tistory.com/entry/Kafka-Docker-Compose%EB%A5%BC-%ED%86%B5%ED%95%B4-Kafka-%EA%B5%AC%EC%B6%95%ED%95%98%EA%B8%B0-Kraft-%EB%AA%A8%EB%93%9C#google_vignette)
- [[kafka] Docker로 카프카 실행하기 (KRaft 모드)](https://curiousjinan.tistory.com/entry/kafka-docker-kraft)

- [Kafka image by bitnami](https://hub.docker.com/r/bitnami/kafka)

- [Debezium images](https://quay.io/organization/debezium)
- [Elasticsearch sink connector module](https://www.confluent.io/hub/confluentinc/kafka-connect-elasticsearch)

- [Elasticsearch image](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html)

- [Monitoring Debezium](https://debezium.io/documentation/reference/stable/operations/monitoring.html)
- [대규모 CDC Pipeline 운영을 위한 Debezium 개선 여정](https://toss.tech/article/cdc_pipeline)


## ✅ 셀프 체크리스트

- [x] 내 코드를 스스로 검토했습니다.
- [ ] 필요한 테스트를 추가했습니다.
- [ ] 모든 테스트를 통과합니다.
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있습니다.
- [x] 커밋 메세지를 컨벤션에 맞추었습니다.
